### PR TITLE
[1.17]server side warning fix

### DIFF
--- a/common/src/main/resources/outvoted.mixins.json
+++ b/common/src/main/resources/outvoted.mixins.json
@@ -5,7 +5,6 @@
   "mixins": [
     "MixinAnvilScreenHandler",
     "MixinBlazeEntity",
-    "MixinBuiltinModelItemRenderer",
     "MixinCorridorExit",
     "MixinMendingEnchantment",
     "MixinServerPlayerEntity",
@@ -17,6 +16,7 @@
   ],
   "client": [
     "GeoArmorRendererAccessor",
+    "MixinBuiltinModelItemRenderer",
     "MixinBlazeRenderer"
   ],
   "injectors": {


### PR DESCRIPTION
in server giving` @Mixin target net.minecraft.class_756 was not found outvoted.mixins.json:MixinBuiltinModelItemRenderer` warning
BuiltinModelItemRenderer class is in client side and not needed to mixing in to server