### PR TITLE
Fixed MixinTexturedRenderLayers mixin loading error on server side

### DIFF
--- a/common/src/main/resources/outvoted.mixins.json
+++ b/common/src/main/resources/outvoted.mixins.json
@@ -11,13 +11,13 @@
     "MixinSignType",
     "MixinSilverfishEntity",
     "MixinSpiderEntity",
-    "MixinTexturedRenderLayers",
     "PointOfInterestTypeAccessor"
   ],
   "client": [
     "GeoArmorRendererAccessor",
     "MixinBuiltinModelItemRenderer",
-    "MixinBlazeRenderer"
+    "MixinBlazeRenderer",
+    "MixinTexturedRenderLayers"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Changed outvoted.mixins.json so that MixinTexturedRenderLayers is a client mixin, avoiding the following error message on fabric server:
```
[main/WARN]: Error loading class: net/minecraft/class_4722 (java.lang.ClassNotFoundException: net/minecraft/class_4722)
[main/WARN]: @Mixin target net.minecraft.class_4722 was not found outvoted.mixins.json:MixinTexturedRenderLayers
```